### PR TITLE
feat(phpunit) Decorrelate test suite from SUT

### DIFF
--- a/classes/test.php
+++ b/classes/test.php
@@ -343,7 +343,6 @@ abstract class test extends atoum\test
             // Based on the comment in `self::getTestedClassName`, it is
             // required to re-adjust the mock engines for constants and
             // functions.
-            $out             = parent::beforeTestMethod($testMethod);
             $testedClassName = self::getTestedClassNameFromTestClass(
                 $this->getClass(),
                 $this->getTestNamespace()
@@ -356,8 +355,6 @@ abstract class test extends atoum\test
 
             $this->getPhpFunctionMocker()->setDefaultNamespace($testedNamespace);
             $this->getPhpConstantMocker()->setDefaultNamespace($testedNamespace);
-
-            return $out;
         }
     }
 }


### PR DESCRIPTION
atoum creates a default relation between a test suite and a class, they
are correlated. PHPUnit doesn't do that. If a test suite extends
`PHPUnit\Framework\TestCase`, then it is assumed that this relation must
be canceled, if a test suite extends `atoum\phpunit\test`, then the
relation is kept. The former is a child of the latter, so it is easy to
implement.

The constant and function mock engines, and the code coverage scores
will not work.