### PR TITLE
fix(test) Test namespace must not include `unit`

### DIFF
--- a/classes/test.php
+++ b/classes/test.php
@@ -14,7 +14,7 @@ abstract class test extends atoum\test
 {
     const defaultMethodPrefix = '/^(test|should)|.*_should_/';
     const defaultEngine = 'inline';
-    const defaultNamespace = '#(?:^|\\\)tests?\\\.*?units?.*?\\\#i';
+    const defaultNamespace = '#(?:^|\\\)tests?\\\#i';
 
     private $unsupportedMethods;
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     ],
     "require": {
         "atoum/atoum": "dev-virtual-hooks as 3.3.0"
-
     },
     "require-dev": {
         "phpunit/phpunit": "@stable"


### PR DESCRIPTION
PHPUnit is not only used for unit tests, but also for integration test
suites.