### PR TITLE
feat(test) Add support for the `@covers`, `@coversNothing`, and `@coversDefaultClass` annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ Enjoy!
 | `@before`                         | ❌         |                                                   |
 | `@beforeClass`                    | ❌         |                                                   |
 | `@codeCoverageIgnore*`            | ❌         |                                                   |
-| `@covers`                         | ❌         |                                                   |
-| `@coversDefaultClass`             | ❌         |                                                   |
-| `@coversNothing`                  | ❌         |                                                   |
+| `@covers`                         | ✅         | Does only consider the class name.                |
+| `@coversDefaultClass`             | ✅         |                                                   |
+| `@coversNothing`                  | ✅         |                                                   |
 | `@dataProvider`                   | ✅         |                                                   |
 | `@depends`                        | ❌         |                                                   |
 | `@expectedException`              | ❌         |                                                   |

--- a/classes/test.php
+++ b/classes/test.php
@@ -268,7 +268,10 @@ abstract class test extends atoum\test
         // scores will not work.
         if (true === $this->breakRelationBetweenTestSuiteAndSUT &&
             $this instanceof PHPUnit\Framework\TestCase) {
-            return $this->defaultTestedClassName ?? 'StdClass';
+            return
+                null !== $this->defaultTestedClassName
+                    ? $this->defaultTestedClassName
+                    : 'StdClass';
         }
 
         $testedClassName = parent::getTestedClassName();


### PR DESCRIPTION
This patch adds support for the following PHPUnit annotations:

  * `@covers`, only the class name is used,
  * `@coversNothing`,
  * `@coversDefaultClass`.