### PR TITLE
fix(asserter) `assert*Empty` no longer rely on `assert*Count`

### DIFF
--- a/classes/constraints/isNotEmpty.php
+++ b/classes/constraints/isNotEmpty.php
@@ -3,27 +3,41 @@
 namespace mageekguy\atoum\phpunit\constraints;
 
 use mageekguy\atoum\asserters;
-use mageekguy\atoum\exceptions;
+use mageekguy\atoum\phpunit\constraint;
 use mageekguy\atoum\tools\variable\analyzer;
 
-class isNotEmpty extends notCount
+class isNotEmpty extends constraint
 {
+    private $analyzer;
+
     public function __construct($description = null, analyzer $analyzer = null)
     {
-        parent::__construct(0, $description, $analyzer);
+        $this->description = $description;
+        $this->analyzer = $analyzer ?: new analyzer();
     }
 
     protected function matches($actual)
     {
-        if ($this->analyzer->isString($actual)) {
-            $asserter = new asserters\phpString(null, $this->analyzer);
-            $asserter->setWith($actual)->isNotEmpty($this->description);
+        if ($actual instanceof \countable) {
+            $asserter = new asserters\sizeOf(null, $this->analyzer);
+            $asserter->setWith($actual)->isNotEqualTo(0, $this->description);
         } else {
-            try {
-                parent::matches($actual);
-            } catch (exceptions\runtime $exception) {
-                throw new exceptions\runtime('Actual value of ' . __CLASS__ . ' must be a string, an array, a countable object, a traversable object');
-            }
+            $asserter = new notEmptyAsserter(null, $this->analyzer);
+            $asserter->setWith($actual)->isNotEmpty($this->description);
         }
+    }
+}
+
+class notEmptyAsserter extends asserters\variable
+{
+    public function isNotEmpty($failMessage = null)
+    {
+        if (!empty($this->valueIsSet()->value)) {
+            $this->pass();
+        } else {
+            $this->fail($failMessage ?: $this->_('%s is empty', $this));
+        }
+
+        return $this;
     }
 }

--- a/tests/units/classes/constraints/isEmpty.php
+++ b/tests/units/classes/constraints/isEmpty.php
@@ -9,7 +9,7 @@ class isEmpty extends \PHPUnit\Framework\TestCase
 {
     public function testClass()
     {
-        $this->assertInstanceOf('mageekguy\atoum\phpunit\constraints\count', new testedClass());
+        $this->assertInstanceOf('mageekguy\atoum\phpunit\constraint', new testedClass());
     }
 
     public function testAssertStringIsEmpty()
@@ -22,9 +22,7 @@ class isEmpty extends \PHPUnit\Framework\TestCase
 
             $this->fail();
         } catch (\PHPUnit\Framework\ExpectationFailedException $exception) {
-            $analyzer = new atoum\tools\variable\analyzer();
-            $diff = new atoum\tools\diff($analyzer->dump(''), $analyzer->dump('foo'));
-            $this->assertEquals('string is not empty' . PHP_EOL . $diff, $exception->getMessage());
+            $this->assertEquals('string(3) \'foo\' is not empty', $exception->getMessage());
         }
     }
 
@@ -38,7 +36,7 @@ class isEmpty extends \PHPUnit\Framework\TestCase
 
             $this->fail();
         } catch (\PHPUnit\Framework\ExpectationFailedException $exception) {
-            $this->assertEquals('array(2) has size 2, expected size 0', $exception->getMessage());
+            $this->assertEquals('array(2) is not empty', $exception->getMessage());
         }
     }
 }

--- a/tests/units/classes/constraints/isNotEmpty.php
+++ b/tests/units/classes/constraints/isNotEmpty.php
@@ -9,7 +9,7 @@ class isNotEmpty extends \PHPUnit\Framework\TestCase
 {
     public function testClass()
     {
-        $this->assertInstanceOf('mageekguy\atoum\phpunit\constraints\notCount', new testedClass());
+        $this->assertInstanceOf('mageekguy\atoum\phpunit\constraint', new testedClass());
     }
 
     public function testAssertStringIsNotEmpty()
@@ -22,7 +22,7 @@ class isNotEmpty extends \PHPUnit\Framework\TestCase
 
             $this->fail();
         } catch (\PHPUnit\Framework\ExpectationFailedException $exception) {
-            $this->assertEquals('string is empty', $exception->getMessage());
+            $this->assertEquals('string(0) \'\' is empty', $exception->getMessage());
         }
     }
 
@@ -36,7 +36,7 @@ class isNotEmpty extends \PHPUnit\Framework\TestCase
 
             $this->fail();
         } catch (\PHPUnit\Framework\ExpectationFailedException $exception) {
-            $this->assertEquals('array(0) has size 0, expected different size', $exception->getMessage());
+            $this->assertEquals('array(0) is empty', $exception->getMessage());
         }
     }
 }


### PR DESCRIPTION
Specific “empty” asserters are added to use the `empty` intrinsic instead of relying on `assert*Count` to mimic the PHPUnit behavior.