### PR TITLE
feat(asserters) Extract asserters from constraints

### DIFF
--- a/classes/asserters/phpArray.php
+++ b/classes/asserters/phpArray.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace mageekguy\atoum\phpunit\asserters;
+
+use mageekguy\atoum;
+
+class phpArray extends atoum\asserters\phpArray
+{
+    public function hasNotSize($size, $failMessage = null)
+    {
+        if (count($this->valueIsSet()->value) != $size) {
+            $this->pass();
+        } else {
+            $this->fail($failMessage ?: $this->_('%s has size %d, expected different size', $this, count($this->valueIsSet()->value), $size));
+        }
+
+        return $this;
+    }
+}

--- a/classes/asserters/phpObject.php
+++ b/classes/asserters/phpObject.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace mageekguy\atoum\phpunit\asserters;
+
+use mageekguy\atoum;
+
+class phpObject extends atoum\asserters\phpObject
+{
+    public function hasAttribute($attribute, $failMessage = null)
+    {
+        if (property_exists($this->valueIsSet()->value, $attribute)) {
+            $this->pass();
+        } else {
+            $this->fail($failMessage ?: $this->_('%s has no attribute `%s`', $this, $attribute));
+        }
+
+        return $this;
+    }
+
+    public function hasNotAttribute($attribute, $failMessage = null)
+    {
+        if (false === property_exists($this->valueIsSet()->value, $attribute)) {
+            $this->pass();
+        } else {
+            $this->fail($failMessage ?: $this->_('%s has attribute `%s`', $this, $attribute));
+        }
+
+        return $this;
+    }
+}

--- a/classes/asserters/variable.php
+++ b/classes/asserters/variable.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace mageekguy\atoum\phpunit\asserters;
+
+use mageekguy\atoum;
+
+class variable extends atoum\asserters\variable
+{
+    public function isEmpty($failMessage = null)
+    {
+        if (empty($this->valueIsSet()->value)) {
+            $this->pass();
+        } else {
+            $this->fail($failMessage ?: $this->_('%s is not empty', $this));
+        }
+
+        return $this;
+    }
+
+    public function isNotEmpty($failMessage = null)
+    {
+        if (!empty($this->valueIsSet()->value)) {
+            $this->pass();
+        } else {
+            $this->fail($failMessage ?: $this->_('%s is empty', $this));
+        }
+
+        return $this;
+    }
+}

--- a/classes/constraints/isEmpty.php
+++ b/classes/constraints/isEmpty.php
@@ -2,7 +2,8 @@
 
 namespace mageekguy\atoum\phpunit\constraints;
 
-use mageekguy\atoum\asserters;
+use mageekguy\atoum\asserters as atoumAsserters;
+use mageekguy\atoum\phpunit\asserters as atoumPHPUnitAsserters;
 use mageekguy\atoum\phpunit\constraint;
 use mageekguy\atoum\tools\variable\analyzer;
 
@@ -19,25 +20,11 @@ class isEmpty extends constraint
     protected function matches($actual)
     {
         if ($actual instanceof \countable) {
-            $asserter = new asserters\sizeOf(null, $this->analyzer);
+            $asserter = new atoumAsserters\sizeOf(null, $this->analyzer);
             $asserter->setWith($actual)->isEqualTo(0, $this->description);
         } else {
-            $asserter = new emptyAsserter(null, $this->analyzer);
+            $asserter = new atoumPHPUnitAsserters\variable(null, $this->analyzer);
             $asserter->setWith($actual)->isEmpty($this->description);
         }
-    }
-}
-
-class emptyAsserter extends asserters\variable
-{
-    public function isEmpty($failMessage = null)
-    {
-        if (empty($this->valueIsSet()->value)) {
-            $this->pass();
-        } else {
-            $this->fail($failMessage ?: $this->_('%s is not empty', $this));
-        }
-
-        return $this;
     }
 }

--- a/classes/constraints/isNotEmpty.php
+++ b/classes/constraints/isNotEmpty.php
@@ -2,7 +2,8 @@
 
 namespace mageekguy\atoum\phpunit\constraints;
 
-use mageekguy\atoum\asserters;
+use mageekguy\atoum\asserters as atoumAsserters;
+use mageekguy\atoum\phpunit\asserters as atoumPHPUnitAsserters;
 use mageekguy\atoum\phpunit\constraint;
 use mageekguy\atoum\tools\variable\analyzer;
 
@@ -19,25 +20,11 @@ class isNotEmpty extends constraint
     protected function matches($actual)
     {
         if ($actual instanceof \countable) {
-            $asserter = new asserters\sizeOf(null, $this->analyzer);
+            $asserter = new atoumAsserters\sizeOf(null, $this->analyzer);
             $asserter->setWith($actual)->isNotEqualTo(0, $this->description);
         } else {
-            $asserter = new notEmptyAsserter(null, $this->analyzer);
+            $asserter = new atoumPHPUnitAsserters\variable(null, $this->analyzer);
             $asserter->setWith($actual)->isNotEmpty($this->description);
         }
-    }
-}
-
-class notEmptyAsserter extends asserters\variable
-{
-    public function isNotEmpty($failMessage = null)
-    {
-        if (!empty($this->valueIsSet()->value)) {
-            $this->pass();
-        } else {
-            $this->fail($failMessage ?: $this->_('%s is empty', $this));
-        }
-
-        return $this;
     }
 }

--- a/classes/constraints/notCount.php
+++ b/classes/constraints/notCount.php
@@ -2,7 +2,8 @@
 
 namespace mageekguy\atoum\phpunit\constraints;
 
-use mageekguy\atoum\asserters;
+use mageekguy\atoum\asserters as atoumAsserters;
+use mageekguy\atoum\phpunit\asserters as atoumPHPUnitAsserters;
 use mageekguy\atoum\phpunit\constraint;
 use mageekguy\atoum\tools\variable\analyzer;
 use PHPUnit;
@@ -17,42 +18,28 @@ class notCount extends count
 
         switch (true) {
             case $this->analyzer->isArray($actual):
-                $asserter = new phpArrayAsserter(null, $this->analyzer);
+                $asserter = new atoumPHPUnitAsserters\phpArray(null, $this->analyzer);
                 $asserter->setWith($actual)->hasNotSize($this->expected, $this->description);
                 break;
 
             case $actual instanceof \countable:
-                $asserter = new asserters\sizeOf(null, $this->analyzer);
+                $asserter = new atoumAsserters\sizeOf(null, $this->analyzer);
                 $asserter->setWith($actual)->isNotEqualTo($this->expected, $this->description);
                 break;
 
             case $actual instanceof \iteratorAggregate:
-                $asserter = new asserters\integer(null, $this->analyzer);
+                $asserter = new atoumAsserters\integer(null, $this->analyzer);
                 $asserter->setWith(iterator_count($actual->getIterator()))->isNotEqualTo($this->expected, $this->description);
                 break;
 
             case $actual instanceof \traversable:
             case $actual instanceof \iterator:
-                $asserter = new asserters\integer(null, $this->analyzer);
+                $asserter = new atoumAsserters\integer(null, $this->analyzer);
                 $asserter->setWith(iterator_count($actual))->isNotEqualTo($this->expected);
                 break;
 
             default:
                 throw new PHPUnit\Framework\Exception('Actual value of ' . __CLASS__ . ' must be an array, a countable object or a traversable object');
         }
-    }
-}
-
-class phpArrayAsserter extends asserters\phpArray
-{
-    public function hasNotSize($size, $failMessage = null)
-    {
-        if (count($this->valueIsSet()->value) != $size) {
-            $this->pass();
-        } else {
-            $this->fail($failMessage ?: $this->_('%s has size %d, expected different size', $this, count($this->valueIsSet()->value), $size));
-        }
-
-        return $this;
     }
 }

--- a/classes/constraints/objectHasAttribute.php
+++ b/classes/constraints/objectHasAttribute.php
@@ -2,11 +2,11 @@
 
 namespace mageekguy\atoum\phpunit\constraints;
 
+use PHPUnit;
 use mageekguy\atoum\asserter\exception;
-use mageekguy\atoum\asserters;
+use mageekguy\atoum\phpunit\asserters;
 use mageekguy\atoum\phpunit\constraint;
 use mageekguy\atoum\tools\variable\analyzer;
-use PHPUnit;
 
 class objectHasAttribute extends constraint
 {
@@ -19,7 +19,7 @@ class objectHasAttribute extends constraint
         $this->analyzer = $analyzer ?: new analyzer();
         $this->attribute = $attribute;
         $this->description = $description;
-        $this->asserter = new objectHasAttributeAsserter(null, $this->analyzer);
+        $this->asserter = new asserters\phpObject(null, $this->analyzer);
     }
 
     protected function matches($actual)
@@ -36,17 +36,3 @@ class objectHasAttribute extends constraint
         $this->asserter->hasAttribute($this->attribute, $this->description);
     }
 }
-
-class objectHasAttributeAsserter extends asserters\phpObject
-{
-    public function hasAttribute($attribute, $failMessage = null)
-    {
-        if (property_exists($this->valueIsSet()->value, $attribute)) {
-            $this->pass();
-        } else {
-            $this->fail($failMessage ?: $this->_('%s has no attribute `%s`', $this, $attribute));
-        }
-
-        return $this;
-    }
-};

--- a/classes/constraints/objectNotHasAttribute.php
+++ b/classes/constraints/objectNotHasAttribute.php
@@ -2,11 +2,11 @@
 
 namespace mageekguy\atoum\phpunit\constraints;
 
+use PHPUnit;
 use mageekguy\atoum\asserter\exception;
-use mageekguy\atoum\asserters;
+use mageekguy\atoum\phpunit\asserters;
 use mageekguy\atoum\phpunit\constraint;
 use mageekguy\atoum\tools\variable\analyzer;
-use PHPUnit;
 
 class objectNotHasAttribute extends constraint
 {
@@ -19,7 +19,7 @@ class objectNotHasAttribute extends constraint
         $this->analyzer = $analyzer ?: new analyzer();
         $this->attribute = $attribute;
         $this->description = $description;
-        $this->asserter = new objectNotHasAttributeAsserter(null, $this->analyzer);
+        $this->asserter = new asserters\phpObject(null, $this->analyzer);
     }
 
     protected function matches($actual)
@@ -34,19 +34,5 @@ class objectNotHasAttribute extends constraint
 
         $this->asserter->setWith($actual);
         $this->asserter->hasNotAttribute($this->attribute, $this->description);
-    }
-}
-
-class objectNotHasAttributeAsserter extends asserters\phpObject
-{
-    public function hasNotAttribute($attribute, $failMessage = null)
-    {
-        if (false === property_exists($this->valueIsSet()->value, $attribute)) {
-            $this->pass();
-        } else {
-            $this->fail($failMessage ?: $this->_('%s has attribute `%s`', $this, $attribute));
-        }
-
-        return $this;
     }
 }


### PR DESCRIPTION
Instead of declaring specific asserters inside the constraint files, they are now extracted into their own files in the `atoum\phpunit\asserters` namespace. The naming is different too to mimic atoum's asserters structure.